### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/app/lib/server/llm/select-context.ts
+++ b/app/lib/server/llm/select-context.ts
@@ -186,11 +186,11 @@ export async function selectContext(props: {
   const includeFiles =
     updateContextBuffer[1]
       .match(/<includeFile path="(.*?)"/gm)
-      ?.map((x) => x.replace('<includeFile path="', '').replace('"', '')) || [];
+      ?.map((x) => x.replace('<includeFile path="', '').replace(/"/g, '')) || [];
   const excludeFiles =
     updateContextBuffer[1]
       .match(/<excludeFile path="(.*?)"/gm)
-      ?.map((x) => x.replace('<excludeFile path="', '').replace('"', '')) || [];
+      ?.map((x) => x.replace('<excludeFile path="', '').replace(/"/g, '')) || [];
 
   const filteredFiles: FileMap = {};
   excludeFiles.forEach((path) => {


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/boltapp3/security/code-scanning/7](https://github.com/EchoCog/boltapp3/security/code-scanning/7)

To fix the problem, we need to ensure that all occurrences of the double quote character are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of the double quote character is replaced, providing more robust sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
